### PR TITLE
feat: 보드게임 검색 API

### DIFF
--- a/packages/functions/.eslintrc.json
+++ b/packages/functions/.eslintrc.json
@@ -27,6 +27,7 @@
   "rules": {
     "import/no-unresolved": 0,
     "max-len": ["error", 120],
-    "new-cap": "off"
+    "new-cap": "off",
+    "@typescript-eslint/no-empty-interface": "off"
   }
 }

--- a/packages/functions/src/search/index.ts
+++ b/packages/functions/src/search/index.ts
@@ -1,27 +1,44 @@
-import express from 'express';
+import express, {Request} from 'express';
 import axios from 'axios';
 import parser from 'xml-js';
-import * as logger from 'firebase-functions/logger';
+import {BoardGameResponse, BoardgameSearchResponse} from './types';
+import {toBoardGame} from './utils';
 
 const router = express.Router();
+const client = axios.create({baseURL: 'https://api.geekdo.com'});
 
-interface Game {
-  _attributes: {
-    objectid: string;
+const getBoardGameIds = async (keyword: string): Promise<string[] | null> => {
+  const {data} = await client.get(`/xmlapi/search?search=${keyword}`);
+  const {boardgames} = JSON.parse(parser.xml2json(data, {compact: true})) as BoardgameSearchResponse;
+  if (!boardgames.boardgame) {
+    return null;
   }
-}
+  const boardGameList = Array.isArray(boardgames.boardgame) ? boardgames.boardgame : [boardgames.boardgame];
+  return boardGameList.map((game: BoardGameResponse) => game._attributes.objectid);
+};
 
-router.get('/', async (req, res) => {
-  const client = axios.create({baseURL: 'https://api.geekdo.com'});
-  const {data} = await client.get('/xmlapi/search?search=브라스');
-  const node = JSON.parse(parser.xml2json(data, {compact: true, spaces: 2}));
-  logger.log(node);
-  const ids = node.boardgames.boardgame.map((game: Game) => game._attributes.objectid);
-  logger.log(ids);
-  const {data: boardgames} = await client.get(`/xmlapi/boardgame/${ids.join(',')}`);
-  logger.log(boardgames);
-  const nodes = parser.xml2json(boardgames, {compact: true, spaces: 2});
-  res.json(nodes);
+const getBoardGamesInfo = async (ids: string[]): Promise<BoardGameResponse[]> => {
+  const {data} = await client.get(`/xmlapi/boardgame/${ids.join(',')}`);
+  const nodes = JSON.parse(parser.xml2json(data, {compact: true}));
+  return nodes.boardgames.boardgame;
+};
+
+interface ReqParams {}
+interface ReqBody {}
+interface ResBody {}
+interface ReqQuery {
+  keyword: string;
+}
+router.get('/', async (req: Request<ReqParams, ReqBody, ResBody, ReqQuery>, res) => {
+  const {keyword} = req.query;
+  const ids = await getBoardGameIds(keyword);
+  if (!ids) {
+    res.json([]);
+    return;
+  }
+  const boardGameResponse = await getBoardGamesInfo(ids);
+  const boardGameList = Array.isArray(boardGameResponse) ? boardGameResponse : [boardGameResponse];
+  res.json(boardGameList.map(toBoardGame));
 });
 
 export default router;

--- a/packages/functions/src/search/types.ts
+++ b/packages/functions/src/search/types.ts
@@ -1,0 +1,58 @@
+export interface Attribute {
+  _attributes: {
+    objectId: string;
+  }
+  _text: string;
+}
+
+export interface Text {
+  _text: string;
+}
+
+export interface BoardGameResponse {
+  _attributes: {
+    objectid: string;
+  },
+  yearpublished: Text;
+  minplayers: Text;
+  maxplayers: Text;
+  playingtime: Text;
+  minplaytime: Text;
+  maxplaytime: Text;
+  age: Text;
+  name: {
+    _attributes: {
+      primary?: string;
+      sortindex: string;
+    }
+    _text: string;
+  }[]
+  descriptions: string;
+  thumbnail: Text;
+  image: Text;
+  boardgamepublisher: Attribute[];
+  boardgameartist: Attribute[];
+  boardgamecategory: Attribute[];
+  boardgamemechanic: Attribute[];
+}
+
+export interface BoardgameSearchResponse {
+  boardgames: {
+    boardgame: BoardGameResponse[];
+  }
+}
+
+export interface BoardGame {
+  id: string;
+  publishedYear: number;
+  minPlayerNum: number;
+  maxPlayerNum: number;
+  playingTime: number;
+  minPlayTime: number;
+  maxPlayTime: number;
+  age: number;
+  name: string;
+  koreanName?: string;
+  thumbnail: string;
+  image: string;
+}

--- a/packages/functions/src/search/utils.ts
+++ b/packages/functions/src/search/utils.ts
@@ -1,0 +1,56 @@
+import {BoardGame, BoardGameResponse} from './types';
+
+const isKorean = (text: string) => /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/.test(text);
+
+export const toBoardGame = (boardGameResponse: BoardGameResponse): BoardGame => {
+  const {
+    _attributes: {
+      objectid: id,
+    },
+    yearpublished: {
+      _text: publishedYear,
+    },
+    minplayers: {
+      _text: minPlayerNum,
+    },
+    maxplayers: {
+      _text: maxPlayerNum,
+    },
+    playingtime: {
+      _text: playingTime,
+    },
+    minplaytime: {
+      _text: minPlayTime,
+    },
+    maxplaytime: {
+      _text: maxPlayTime,
+    },
+    age: {
+      _text: age,
+    },
+    name: nameCandidates,
+    thumbnail: {
+      _text: thumbnail,
+    },
+    image: {
+      _text: image,
+    },
+  } = boardGameResponse;
+
+  const name = nameCandidates.find(({_attributes}) => Boolean(_attributes.primary))?._text || '';
+  const koreanName = nameCandidates.find(({_text}) => isKorean(_text))?._text;
+  return {
+    id,
+    publishedYear: Number(publishedYear),
+    maxPlayerNum: Number(maxPlayerNum),
+    minPlayerNum: Number(minPlayerNum),
+    playingTime: Number(playingTime),
+    maxPlayTime: Number(maxPlayTime),
+    minPlayTime: Number(minPlayTime),
+    age: Number(age),
+    name,
+    koreanName,
+    thumbnail,
+    image,
+  };
+};


### PR DESCRIPTION
## 작업 내용
- 보드게임 검색 API

## 사용 방법
1. `yarn fb serve`
2. `http://127.0.0.1:5001/boardgame-rental/asia-northeast3/api/search?keyword=<검색하고싶은 보드게임 키워드>`
3. 포트는 다를 수 있음 (5001 말고 5000이나 4000, 4001 일수도)

## 스크린샷

## 체크리스트

- [ ] lint 통과
- [ ] 정상동작 확인

## 논의사항

Close #이슈번호
