### PR TITLE
feat: 카카오 로그인 유저 db 저장

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "eject": "yarn workspace client run eject",
     "lint": "yarn workspaces run lint",
     "lint:fix": "yarn workspace client run lint:fix",
-    "fb": "yarn workspace functions",
-    "prepare": "husky install"
+    "fb": "yarn workspace functions"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,6 +21,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^3.11.0",
+    "react-query": "^3.39.3",
     "react-router-dom": "^6.9.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
@@ -31,8 +32,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint .",
-    "lint:fix": "eslint --fix .",
-    "prepare": "husky install"
+    "lint:fix": "eslint --fix ."
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -54,5 +54,8 @@
       "prettier --write",
       "eslint --fix"
     ]
+  },
+  "devDependencies": {
+    "@types/react-query": "^1.2.9"
   }
 }

--- a/packages/client/src/AuthProvider.tsx
+++ b/packages/client/src/AuthProvider.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback, useContext, useMemo, useState } from 'react';
+import { User } from './models/user';
+
+const defaultAction = {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  login: (loginUser: User) => {},
+  logout: () => {},
+};
+
+const AuthStateContext = React.createContext<User | null>(null);
+const AuthActionContext = React.createContext(defaultAction);
+
+export const useAuthContext = () => {
+  const user = useContext(AuthStateContext);
+  const { login, logout } = useContext(AuthActionContext);
+
+  return {
+    user,
+    login,
+    logout,
+  };
+};
+
+const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  const login = useCallback((loginUser: User) => setUser(loginUser), [setUser]);
+  const logout = useCallback(() => setUser(null), [setUser]);
+
+  const action = useMemo(
+    () => ({
+      login,
+      logout,
+    }),
+    [login, logout]
+  );
+
+  return (
+    <AuthActionContext.Provider value={action}>
+      <AuthStateContext.Provider value={user}>
+        {children}
+      </AuthStateContext.Provider>
+    </AuthActionContext.Provider>
+  );
+};
+
+export default AuthProvider;

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -1,15 +1,23 @@
 import { ColorModeScript } from '@chakra-ui/react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { App } from './App';
+import AuthProvider from './AuthProvider';
 
 const container = document.getElementById('root');
 if (!container) throw new Error('Failed to find the root element');
 const root = ReactDOM.createRoot(container);
 
+const queryClient = new QueryClient();
+
 root.render(
   <React.StrictMode>
-    <ColorModeScript />
-    <App />
+    <AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <ColorModeScript />
+        <App />
+      </QueryClientProvider>
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/packages/client/src/models/user.ts
+++ b/packages/client/src/models/user.ts
@@ -1,0 +1,5 @@
+export interface User {
+  uid: string;
+  name: string;
+  boardGames: [];
+}

--- a/packages/client/src/pages/KakaoLogin.tsx
+++ b/packages/client/src/pages/KakaoLogin.tsx
@@ -1,39 +1,81 @@
 import React, { useEffect } from 'react';
-import { ChakraProvider, Box, Text, Grid, theme } from '@chakra-ui/react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { useQuery } from 'react-query';
 import axios from 'axios';
-import { ColorModeSwitcher } from '../ColorModeSwitcher';
+import { Spinner } from '@chakra-ui/react';
+import { useAuthContext } from '../AuthProvider';
 
 const KakaoLogin = () => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    const code = window.location.search.split('code=').pop();
-    axios
-      .post(
-        'https://kauth.kakao.com/oauth/token',
-        {
-          grant_type: 'authorization_code',
-          client_id: process.env.REACT_APP_KAKAO_CLIENT_ID,
-          redirect_uri: 'http://localhost:3000/login/kakao',
-          code,
-        },
-        {
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+  const searchParams = new URLSearchParams(window.location.search);
+  const code = searchParams.get('code');
+  const navigate = useNavigate();
+
+  const { data } = useQuery(
+    '/auth/kakao/token',
+    () =>
+      axios
+        .post(
+          'https://kauth.kakao.com/oauth/token',
+          {
+            grant_type: 'authorization_code',
+            client_id: process.env.REACT_APP_KAKAO_CLIENT_ID,
+            redirect_uri: 'http://localhost:3000/login/kakao',
+            code,
           },
-        }
-      )
-      .then(({ data }) => console.log(data));
-  }, []);
-  return (
-    <ChakraProvider theme={theme}>
-      <Box textAlign="center" fontSize="xl">
-        <Grid minH="100vh" p={3}>
-          <ColorModeSwitcher justifySelf="flex-end" />
-          <Text>Login</Text>
-        </Grid>
-      </Box>
-    </ChakraProvider>
+          {
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+            },
+          }
+        )
+        .then((res) => res.data),
+    {
+      enabled: !!code,
+    }
   );
+
+  useEffect(() => {
+    if (data) {
+      localStorage.setItem('access_token', data.access_token);
+      localStorage.setItem('refresh_token', data.refresh_token);
+    }
+  }, [data]);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { data: user } = useQuery(
+    '/auth/kakao/user',
+    () =>
+      axios
+        .post(
+          'http://localhost:5001/boardgame-rental/asia-northeast3/api/auth/kakao',
+          {
+            accessToken: data.access_token,
+          },
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }
+        )
+        .then((res) => res.data),
+    {
+      enabled: !!data,
+    }
+  );
+
+  const { login } = useAuthContext();
+  useEffect(() => {
+    if (user) {
+      login(user);
+      navigate(`/list/${user.uid}`);
+    }
+  }, [user, login, navigate]);
+
+  if (!code) {
+    return <Navigate to="/login" />;
+  }
+
+  return <Spinner />;
 };
 
 export default KakaoLogin;

--- a/packages/functions/.eslintrc.json
+++ b/packages/functions/.eslintrc.json
@@ -26,6 +26,12 @@
   ],
   "rules": {
     "import/no-unresolved": 0,
+    "import/named": 0,
+    "import/no-named-as-default": 0,
+    "import/no-named-as-default-member": 0,
+    "import/namespace": 0,
+    "import/default": 0,
+    "import/export": 0,
     "max-len": ["error", 120],
     "new-cap": "off",
     "@typescript-eslint/no-empty-interface": "off"

--- a/packages/functions/src/auth/index.ts
+++ b/packages/functions/src/auth/index.ts
@@ -1,9 +1,37 @@
 import express from 'express';
+import axios from 'axios';
+import {KakaoUser} from './types';
+import {db} from '..';
 
 const router = express.Router();
 
 router.get('/', (req, res) => {
   res.status(200).send('auth');
+});
+
+const createUser = (uid: string, name: string) => ({
+  uid,
+  name,
+  boardGames: [],
+});
+
+router.post('/kakao', async (req, res) => {
+  const {accessToken} = req.body;
+  console.log(accessToken);
+  const {data: user} = await axios.get<KakaoUser>('https://kapi.kakao.com/v2/user/me', {
+    headers: {Authorization: `Bearer ${accessToken}`},
+  });
+  console.log(user);
+  const userRef = db.collection('users').doc(`${user.id}`);
+
+  const userData = await userRef.get();
+  if (userData.exists) {
+    res.json(userData.data());
+  } else {
+    const newUser = createUser(`${user.id}`, user.kakao_account?.profile?.nickname || '');
+    await userRef.set(newUser);
+    res.json(newUser);
+  }
 });
 
 export default router;

--- a/packages/functions/src/auth/types.ts
+++ b/packages/functions/src/auth/types.ts
@@ -1,0 +1,12 @@
+interface KakaoProfile {
+  nickname: string;
+}
+
+interface KakaoAccount {
+  profile?: KakaoProfile;
+}
+
+export interface KakaoUser {
+  id: number;
+  kakao_account?: KakaoAccount;
+}

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -5,7 +5,8 @@ import authRouter from './auth';
 import searchRouter from './search';
 import cors from 'cors';
 
-admin.initializeApp();
+admin.initializeApp(functions.config().firebase);
+export const db = admin.firestore();
 
 const app = express();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1036,7 +1036,7 @@
   resolved "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.21.0"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -3314,6 +3314,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-query@^1.2.9":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@types/react-query/-/react-query-1.2.9.tgz#61df5a0594ea4b90234f9c0fdd8f12a06e331fed"
+  integrity sha512-xfVcv5zjC6fGf6axPyKxdXNm9RKK9OFzSIyZeCR3r9h4zDuqSpHc8ilTBtfQ1zU/uCx+tAsB+W6vzdCBMu1jtg==
+  dependencies:
+    react-query "*"
+
 "@types/react-router-dom@^5.3.3":
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
@@ -4190,6 +4197,11 @@ bfj@^7.0.2:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz"
@@ -4264,6 +4276,20 @@ braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -5074,7 +5100,7 @@ detect-node-es@^1.1.0:
   resolved "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz"
   integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
-detect-node@^2.0.4:
+detect-node@^2.0.4, detect-node@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -7731,6 +7757,11 @@ js-sdsl@^4.1.4:
   resolved "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz"
   integrity sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -8237,6 +8268,14 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 mdn-data@2.0.14:
   version "2.0.14"
   resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz"
@@ -8286,6 +8325,11 @@ micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   dependencies:
     braces "^3.0.2"
     picomatch "^2.3.1"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
@@ -8384,6 +8428,13 @@ multicast-dns@^7.2.5:
   dependencies:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -8575,6 +8626,11 @@ object.values@^1.1.0, object.values@^1.1.6:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -9734,6 +9790,15 @@ react-is@^18.0.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-query@*, react-query@^3.39.3:
+  version "3.39.3"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.3.tgz#4cea7127c6c26bdea2de5fb63e51044330b03f35"
+  integrity sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz"
@@ -9957,6 +10022,11 @@ relateurl@^0.2.7:
   resolved "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
+
 renderkid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz"
@@ -10065,7 +10135,7 @@ rfdc@^1.3.0:
   resolved "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -11104,6 +11174,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## 작업 내용
back
- 카카오 로그인 token으로 유저 정보 가져오기
- 유저 정보 firestore에 저장
front
- access_token, refresh_token 로컬 스토리지에 저장
- 로그인 된 유저 정보 context에 저장
- 로그인 완료시 리스트 페이지로 이동

TODO:
- 액세스 토큰 만료 관리

## 스크린샷

## 체크리스트

- [ ] lint 통과
- [ ] 정상동작 확인

## 논의사항

Close #이슈번호
