### PR TITLE
feat: Clipboard API를 사용하여 링크 복사 기능 구현 #9

### DIFF
--- a/packages/client/src/components/ShareButton.tsx
+++ b/packages/client/src/components/ShareButton.tsx
@@ -11,13 +11,10 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { LinkIcon } from '@chakra-ui/icons';
-import { useLocation } from 'react-router-dom';
 
 const ShareButton = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const toast = useToast();
-  const location = useLocation();
-  const link = `http://localhost:3000${location.pathname}`;
 
   const copyClipboard = async (
     text: string,
@@ -64,7 +61,7 @@ const ShareButton = () => {
               mr={3}
               onClick={() =>
                 copyClipboard(
-                  link,
+                  window.location.href,
                   () =>
                     toast({
                       title: '링크가 클립보드에 저장되었습니다.',

--- a/packages/client/src/components/ShareButton.tsx
+++ b/packages/client/src/components/ShareButton.tsx
@@ -8,11 +8,30 @@ import {
   ModalHeader,
   ModalOverlay,
   useDisclosure,
+  useToast,
 } from '@chakra-ui/react';
 import { LinkIcon } from '@chakra-ui/icons';
+import { useLocation } from 'react-router-dom';
 
 const ShareButton = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const toast = useToast();
+  const location = useLocation();
+  const link = `http://localhost:3000${location.pathname}`;
+
+  const copyClipboard = async (
+    text: string,
+    successAction?: () => void,
+    failAction?: () => void
+  ) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      return successAction && successAction();
+    } catch (error) {
+      return failAction && failAction();
+    }
+  };
+
   return (
     <>
       <IconButton
@@ -39,7 +58,30 @@ const ShareButton = () => {
           <ModalHeader>공유하기</ModalHeader>
           <ModalCloseButton />
           <ModalBody display="flex" flexDirection="column" gap={2} mb={3}>
-            <Button colorScheme="blue" variant="outline" mr={3}>
+            <Button
+              colorScheme="blue"
+              variant="outline"
+              mr={3}
+              onClick={() =>
+                copyClipboard(
+                  link,
+                  () =>
+                    toast({
+                      title: '링크가 클립보드에 저장되었습니다.',
+                      status: 'success',
+                      duration: 1000,
+                      isClosable: true,
+                    }),
+                  () =>
+                    toast({
+                      title: '다시 시도해주세요.',
+                      status: 'success',
+                      duration: 1000,
+                      isClosable: true,
+                    })
+                )
+              }
+            >
               링크로 공유하기
             </Button>
             <Button colorScheme="yellow" mr={3}>


### PR DESCRIPTION
## 작업 내용

- chakra의 toast와 Clipboard API 복사기능 적용

## 스크린샷
![스크린샷 2023-03-25 20 25 38](https://user-images.githubusercontent.com/74060716/227714647-c99deb53-baa3-4abd-a803-a850631ba56a.png)

## 체크리스트

- [x] lint 통과
- [x] 정상동작 확인

## 논의사항

Close #9 
